### PR TITLE
Performance enhancement on fromBuffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,7 +259,9 @@ BitArray.fromBuffer = function(buf) {
   for (var i = 0; i < buf.length; i++) {
     bits += BitArray.from32Integer(buf[i]).__bits.join('')
   }
-  return new BitArray().set(bits.split('').map(i => parseInt(i)))
+  return new BitArray().set(bits.split('').map(function (i) {
+    return parseInt(i)
+  }))
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -255,11 +255,11 @@ BitArray.from32Integer = function(num) {
 
 BitArray.fromRedis =
 BitArray.fromBuffer = function(buf) {
-  var bits = []
+  var bits = ''
   for (var i = 0; i < buf.length; i++) {
-    bits = bits.concat(BitArray.from32Integer(buf[i]).toJSON())
+    bits += BitArray.from32Integer(buf[i]).__bits.join('')
   }
-  return new BitArray().set(bits)
+  return new BitArray().set(bits.split('').map(i => parseInt(i)))
 }
 
 /**


### PR DESCRIPTION
The performance of Array.concat was taking a hit when using a buffer that 401025 bytes in length. Appending to a string is faster
